### PR TITLE
Added RECEIVER_NOT_EXPORTED for API33+

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/CustomNavigationNotification.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/CustomNavigationNotification.java
@@ -68,7 +68,12 @@ public class CustomNavigationNotification implements NavigationNotification {
 
     public void register(BroadcastReceiver stopNavigationReceiver, Context applicationContext) {
         this.stopNavigationReceiver = stopNavigationReceiver;
-        applicationContext.registerReceiver(stopNavigationReceiver, new IntentFilter(STOP_NAVIGATION_ACTION));
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            applicationContext.registerReceiver(stopNavigationReceiver, new IntentFilter(STOP_NAVIGATION_ACTION), Context.RECEIVER_NOT_EXPORTED);
+        } else {
+            applicationContext.registerReceiver(stopNavigationReceiver, new IntentFilter(STOP_NAVIGATION_ACTION));
+        }
     }
 
     private PendingIntent createPendingStopIntent(Context context) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/MapBatteryMonitor.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/MapBatteryMonitor.java
@@ -28,6 +28,10 @@ class MapBatteryMonitor {
 
   private static Intent registerBatteryUpdates(Context context) {
     IntentFilter filter = new IntentFilter(Intent.ACTION_BATTERY_CHANGED);
-    return context.registerReceiver(null, filter);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      return context.registerReceiver(null, filter, Context.RECEIVER_NOT_EXPORTED);
+    } else {
+      return context.registerReceiver(null, filter);
+    }
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/core/connectivity/ConnectivityReceiver.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/core/connectivity/ConnectivityReceiver.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
+import android.os.Build;
 
 import androidx.annotation.UiThread;
 
@@ -127,7 +128,11 @@ public class ConnectivityReceiver extends BroadcastReceiver {
     @UiThread
     public void requestConnectivityUpdates() {
         if (activationCounter == 0) {
-            context.registerReceiver(this, new IntentFilter("android.net.conn.CONNECTIVITY_CHANGE"));
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                context.registerReceiver(this, new IntentFilter("android.net.conn.CONNECTIVITY_CHANGE"), Context.RECEIVER_NOT_EXPORTED);
+            } else {
+                context.registerReceiver(this, new IntentFilter("android.net.conn.CONNECTIVITY_CHANGE"));
+            }
         }
         activationCounter++;
     }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotification.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotification.java
@@ -1,5 +1,6 @@
 package com.mapbox.services.android.navigation.v5.navigation;
 
+import android.annotation.SuppressLint;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
@@ -151,7 +152,11 @@ class MapboxNavigationNotification implements NavigationNotification {
 
   private void registerReceiver(Context context) {
     if (context != null) {
-      context.registerReceiver(endNavigationBtnReceiver, new IntentFilter(END_NAVIGATION_ACTION));
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        context.registerReceiver(endNavigationBtnReceiver, new IntentFilter(END_NAVIGATION_ACTION), Context.RECEIVER_NOT_EXPORTED)
+      } else {
+        context.registerReceiver(endNavigationBtnReceiver, new IntentFilter(END_NAVIGATION_ACTION));
+      }
     }
   }
 


### PR DESCRIPTION
- Corrected API33+ `context.registerReceiver` requirement w/ `Context.RECEIVER_NOT_EXPORTED` for all registration calls.